### PR TITLE
Feature: sort by route path-name

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ You can find examples in the [examples](https://github.com/alexschimpf/fastapi-v
   - You can generate each versioned Redoc page using `get_redoc` and `redoc_url`
     - This is useful if you need to want to customize your Redoc HTML using `fastapi.openapi.docs.get_redoc_html`
     - The usage of this is very similar to `get_docs`
+  - You can sort the routes within a version to occur by route-path-name using `sorted_routes` see 
+    the Sorted Example for more details.
   - You can pass additional `kwargs` that will be supplied to each versioned sub-application
     - Note: `app.title` and `app.description` are automatically supplied to each versioned sub-application
     - For all other FastAPI parameters, these must be passed via `kwargs`

--- a/examples/advanced.py
+++ b/examples/advanced.py
@@ -37,23 +37,35 @@ app = FastAPI(
 
 @app.post('/do_something', tags=['Something'], response_model=TestModel)
 async def do_something(test: TestModel) -> Any:
+    """
+    default version -> /do_something
+    """
     return test
 
 
 @app.post('/do_something_else', tags=['Something Else'])
 async def do_something_else() -> Any:
+    """
+    default version -> /do_something_else
+    """
     return {'message': 'something else'}
 
 
 @api_version(2)
 @app.post('/do_something', tags=['Something'])
 async def do_something_v2() -> Any:
+    """
+    version 2 -> /do_something
+    """
     return {'message': 'something'}
 
 
 @api_version(2)
 @app.post('/do_something_new', tags=['Something New'])
 async def do_something_new() -> Any:
+    """
+    version 2 -> /do_something_new
+    """
     return {'message': 'something new'}
 
 
@@ -118,7 +130,8 @@ versions = versionize(
     docs_url='/specs',
     enable_latest=True,
     latest_prefix='/latest',
-    swagger_ui_parameters={'defaultModelsExpandDepth': -1}
+    swagger_ui_parameters={'defaultModelsExpandDepth': -1},
+    sorted_routes=False
 )
 
 

--- a/examples/sorted.py
+++ b/examples/sorted.py
@@ -1,0 +1,65 @@
+from typing import Any
+
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+from fastapi_versionizer.versionizer import api_version, versionize
+
+
+app = FastAPI(
+    title='My Versioned API (route-path sorted)',
+    description='Look, I can version my APIs and sort the route-paths!',
+)
+
+
+class TestModel(BaseModel):
+    something: str
+
+
+@app.post('/xxx_do_something', tags=['Something'], response_model=TestModel)
+async def do_something(test: TestModel) -> Any:
+    return test
+
+
+@app.post('/bbb_do_something_else', tags=['Something Else'])
+async def do_something_else() -> Any:
+    return {'message': 'something else'}
+
+
+@api_version(2)
+@app.post('/xxx_do_something', tags=['Something'])
+async def do_something_v2() -> Any:
+    return {'message': 'something'}
+
+
+@api_version(2)
+@app.post('/aaa_do_something_new', tags=['Something New'])
+async def do_something_new() -> Any:
+    return {'message': 'something new'}
+
+
+@api_version(2, 1)
+@app.post('/aaa_do_something_new', tags=['Something New'])
+async def do_something_newer() -> Any:
+    return {'message': 'something newer'}
+
+
+'''
+- Notes:
+    - "/v1.0/docs" and "/v2.0/docs" pages are generated, because `docs_url` is given
+    - "/versions" is automatically generated
+
+- We test and seek the following endpoints:
+    - /v1.0/xxx_do_something
+    - /v1.0/bbb_do_something_else
+    - /v2.0/xxx_do_something
+    - /v2.0/bbb_do_something_else
+    - /v2.0/aaa_do_something_new
+    - /v2.1/aaa_do_something_new
+'''
+versions = versionize(
+    app=app,
+    prefix_format='/v{major}.{minor}',
+    docs_url='/docs',
+    sorted_routes=True
+)

--- a/examples/sorted.py
+++ b/examples/sorted.py
@@ -61,5 +61,7 @@ versions = versionize(
     app=app,
     prefix_format='/v{major}.{minor}',
     docs_url='/docs',
+    enable_latest=True,
+    latest_prefix='/latest',
     sorted_routes=True
 )

--- a/fastapi_versionizer/versionizer.py
+++ b/fastapi_versionizer/versionizer.py
@@ -127,7 +127,7 @@ def versionize(
             app=app,
             version=version,
             semver=semver,
-            unique_routes=unique_routes,
+            unique_routes=dict(sorted(unique_routes.items())) if sorted_routes else unique_routes,
             get_openapi=get_openapi,
             get_docs=get_docs,
             get_redoc=get_redoc,

--- a/fastapi_versionizer/versionizer.py
+++ b/fastapi_versionizer/versionizer.py
@@ -41,6 +41,7 @@ def versionize(
     default_version: Tuple[int, int] = (1, 0),
     enable_latest: bool = False,
     latest_prefix: str = '/latest',
+    sorted_routes: bool = False,
     get_openapi: Union[Callable[[FastAPI, Tuple[int, int]], Dict[str, Any]], None] = None,
     get_docs: Union[Callable[[Tuple[int, int]], HTMLResponse], None] = None,
     get_redoc: Union[Callable[[Tuple[int, int]], HTMLResponse], None] = None,
@@ -63,6 +64,8 @@ def versionize(
     :param latest_prefix:
         - Defines the prefix use for the "latest" endpoints (if `enabled_latest` is True)
         - This cannot be "/"
+    :param sorted_routes:
+        - Sort the routes within a version to occur by route-path-name
     :param get_openapi:
         - A function that takes in a versioned FastAPI sub-application and a version (in tuple forms)
         - and returns an OpenAPI schema dict.
@@ -108,7 +111,7 @@ def versionize(
             app=app,
             version=version,
             semver=semver,
-            unique_routes=unique_routes,
+            unique_routes=dict(sorted(unique_routes.items())) if sorted_routes else unique_routes,
             get_openapi=get_openapi,
             get_docs=get_docs,
             get_redoc=get_redoc,

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -5,3 +5,5 @@ mypy==0.971
 pydantic==1.9.2
 twine==3.8.0
 types-setuptools==65.6.0.2
+httpx==0.23.3
+uvicorn==0.20.0

--- a/tests/test_advanced.py
+++ b/tests/test_advanced.py
@@ -127,6 +127,7 @@ class TestAdvanced(TestCase):
                             'Something'
                         ],
                         'summary': 'Do Something',
+                        'description': 'default version -> /do_something',
                         'operationId': 'do_something_do_something_post',
                         'requestBody': {
                             'content': {
@@ -178,13 +179,14 @@ class TestAdvanced(TestCase):
                             'Something Else'
                         ],
                         'summary': 'Do Something Else',
+                        'description': 'default version -> /do_something_else',
                         'operationId': 'do_something_else_do_something_else_post',
                         'responses': {
                             '200': {
                                 'description': 'Successful Response',
                                 'content': {
                                     'application/json': {
-                                        'schema': {}
+                                        'schema': {'title': 'Response Do Something Else Do Something Else Post'}
                                     }
                                 }
                             },
@@ -226,13 +228,14 @@ class TestAdvanced(TestCase):
                             'Something'
                         ],
                         'summary': 'Do Something V2',
+                        'description': 'version 2 -> /do_something',
                         'operationId': 'do_something_v2_do_something_post',
                         'responses': {
                             '200': {
                                 'description': 'Successful Response',
                                 'content': {
                                     'application/json': {
-                                        'schema': {}
+                                        'schema': {'title': 'Response Do Something V2 Do Something Post'}
                                     }
                                 }
                             },
@@ -265,13 +268,14 @@ class TestAdvanced(TestCase):
                             'Something Else'
                         ],
                         'summary': 'Do Something Else',
+                        'description': 'default version -> /do_something_else',
                         'operationId': 'do_something_else_do_something_else_post',
                         'responses': {
                             '200': {
                                 'description': 'Successful Response',
                                 'content': {
                                     'application/json': {
-                                        'schema': {}
+                                        'schema': {'title': 'Response Do Something Else Do Something Else Post'}
                                     }
                                 }
                             },
@@ -304,13 +308,14 @@ class TestAdvanced(TestCase):
                             'Something New'
                         ],
                         'summary': 'Do Something New',
+                        'description': 'version 2 -> /do_something_new',
                         'operationId': 'do_something_new_do_something_new_post',
                         'responses': {
                             '200': {
                                 'description': 'Successful Response',
                                 'content': {
                                     'application/json': {
-                                        'schema': {}
+                                        'schema': {'title': 'Response Do Something New Do Something New Post'}
                                     }
                                 }
                             },

--- a/tests/test_sorted.py
+++ b/tests/test_sorted.py
@@ -45,6 +45,11 @@ class TestSorted(TestCase):
 
         self.assertListEqual(
             ['/aaa_do_something_new', '/bbb_do_something_else', '/xxx_do_something'],
+            list(test_client.get('/latest/openapi.json').json()['paths'].keys())
+        )
+
+        self.assertListEqual(
+            ['/aaa_do_something_new', '/bbb_do_something_else', '/xxx_do_something'],
             list(test_client.get('/v2.1/openapi.json').json()['paths'].keys())
         )
 

--- a/tests/test_sorted.py
+++ b/tests/test_sorted.py
@@ -1,0 +1,54 @@
+from fastapi.testclient import TestClient
+
+from unittest import TestCase
+from examples.sorted import app, versions
+
+
+class TestSorted(TestCase):
+
+    def test_sorted(self) -> None:
+        test_client = TestClient(app)
+
+        self.assertListEqual([(1, 0), (2, 0), (2, 1)], versions)
+        self.assertEqual(404, test_client.get('/').status_code)
+
+        self.assertEqual(200, test_client.get('/v1.0/openapi.json').status_code)
+        self.assertEqual(200, test_client.post('/v1.0/xxx_do_something', json={'something': 'something'}).status_code)
+        self.assertEqual(200, test_client.post('/v1.0/bbb_do_something_else').status_code)
+        self.assertEqual(404, test_client.post('/v1.0/aaa_do_something_new').status_code)
+
+        self.assertEqual(200, test_client.get('/v2.0/openapi.json').status_code)
+        self.assertEqual(200, test_client.post('/v2.0/xxx_do_something').status_code)
+        self.assertEqual(200, test_client.post('/v2.0/bbb_do_something_else').status_code)
+        self.assertEqual(200, test_client.post('/v2.0/aaa_do_something_new').status_code)
+
+        self.assertEqual(200, test_client.post('/v2.1/aaa_do_something_new').status_code)
+
+        self.assertDictEqual(
+            {
+                'title': 'My Versioned API (route-path sorted)',
+                'description': 'Look, I can version my APIs and sort the route-paths!',
+                'version': '2.1'
+            },
+            test_client.get('/v2.1/openapi.json').json()['info']
+        )
+
+        self.assertListEqual(
+            ['/bbb_do_something_else', '/xxx_do_something'],
+            list(test_client.get('/v1.0/openapi.json').json()['paths'].keys())
+        )
+
+        self.assertListEqual(
+            ['/aaa_do_something_new', '/bbb_do_something_else', '/xxx_do_something'],
+            list(test_client.get('/v2.0/openapi.json').json()['paths'].keys())
+        )
+
+        self.assertListEqual(
+            ['/aaa_do_something_new', '/bbb_do_something_else', '/xxx_do_something'],
+            list(test_client.get('/v2.1/openapi.json').json()['paths'].keys())
+        )
+
+        self.assertEqual(
+            'Do Something Newer',
+            test_client.get('/v2.1/openapi.json').json()['paths']['/aaa_do_something_new']['post']['summary']
+        )


### PR DESCRIPTION
Hi - we needed the ability to sort by route path-name within a version, sharing upstream herewith.

Some points
- sorted tests, documents and examples are provided
- we've updated the existing `advanced` test since it was failing pre this fork, might be related to a newer FastAPI version
- we added `httpx` and `uvicorn` to the development `requirements.txt` since these are required and were otherwise missing when trying to test etc