### PR TITLE
Support for FastAPI subclasses and removed routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ You can find examples in the [examples](https://github.com/alexschimpf/fastapi-v
 ## Details
 - Routes can be annotated using the `@api_version` decorator
   - This essentially says, "This route is available from version (major, minor) onward, until a new version of the route is defined."
+- Routes can be annotated using the `@api_version_remove` decorator
+  - This essentially says, "This route is removed from version (major, minor) onward, until a new version of the route is defined again."
 - Use the `versionize` function on your FastAPI app to perform the versionizing magic
   - Each version results in a new mounted FastAPI sub-application with a version prefix you define
   - Unlike `fastapi_versioning`, this does not return a new FastAPI app, but applies the versioning directly to the app you provide

--- a/examples/simple.py
+++ b/examples/simple.py
@@ -3,7 +3,7 @@ from typing import Any
 from fastapi import FastAPI
 from pydantic import BaseModel
 
-from fastapi_versionizer.versionizer import api_version, versionize
+from fastapi_versionizer.versionizer import api_version, api_version_remove, versionize
 
 
 app = FastAPI(
@@ -27,15 +27,23 @@ async def do_something_else() -> Any:
 
 
 @api_version(2)
+@api_version_remove(3)
 @app.post('/do_something', tags=['Something'])
 async def do_something_v2() -> Any:
     return {'message': 'something'}
 
 
 @api_version(2)
+@api_version_remove(3)
 @app.post('/do_something_new', tags=['Something New'])
 async def do_something_new() -> Any:
     return {'message': 'something new'}
+
+
+@api_version(4)
+@app.post('/do_something', tags=['Something'])
+async def do_something_v4() -> Any:
+    return {'message': 'something re-added'}
 
 
 '''
@@ -47,17 +55,30 @@ async def do_something_new() -> Any:
 - This will create the following endpoints:
     - /openapi.json
     - /versions
+    
     - /v1/docs
     - /v1/redoc
     - /v1/openapi.json
     - /v1/do_something
     - /v1/do_something_else
+    
     - /v2/docs
     - /v2/redoc
     - /v2/openapi.json    
     - /v2/do_something
     - /v2/do_something_else
     - /v2/do_something_new
+    
+    - /v3/docs
+    - /v3/redoc
+    - /v3/openapi.json    
+    - /v3/do_something_else
+    
+    - /v4/docs
+    - /v4/redoc
+    - /v4/openapi.json    
+    - /v4/do_something
+    - /v4/do_something_else
 '''
 versions = versionize(
     app=app,

--- a/fastapi_versionizer/versionizer.py
+++ b/fastapi_versionizer/versionizer.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from typing import Any, Callable, Dict, List, Tuple, TypeVar, cast, Union, Optional
+from typing import Any, Callable, Dict, List, Tuple, TypeVar, cast, Union
 
 from fastapi import FastAPI
 from fastapi.responses import HTMLResponse
@@ -170,7 +170,7 @@ def versionize(
     return versions
 
 
-def _get_unique_route_keys(route: BaseRoute) -> list[str]:
+def _get_unique_route_keys(route: BaseRoute) -> List[str]:
     result = []
     if isinstance(route, APIRoute):
         for method in route.methods:
@@ -219,7 +219,7 @@ def _get_version_remove_route_mapping(
 
 def _version_remove_to_route(
     route: BaseRoute,
-) -> Tuple[Optional[Tuple[int, int]], BaseRoute]:
+) -> Tuple[Union[Tuple[int, int], None], BaseRoute]:
     api_route = cast(Route, route)
     version = getattr(api_route.endpoint, '_api_version_remove', None)
     return version, api_route

--- a/fastapi_versionizer/versionizer.py
+++ b/fastapi_versionizer/versionizer.py
@@ -8,6 +8,7 @@ from starlette.routing import BaseRoute, Route, WebSocketRoute
 from pydantic import BaseModel
 
 CallableT = TypeVar('CallableT', bound=Callable[..., Any])
+FastAPIT = TypeVar('FastAPIT', bound=FastAPI)
 
 
 class VersionModel(BaseModel):
@@ -176,7 +177,7 @@ def _version_to_route(
 
 
 def _build_versioned_app(
-    app: FastAPI,
+    app: FastAPIT,
     version: Tuple[int, int],
     semver: str,
     unique_routes: Dict[str, BaseRoute],
@@ -184,10 +185,10 @@ def _build_versioned_app(
     get_docs: Union[Callable[[Tuple[int, int]], HTMLResponse], None] = None,
     get_redoc: Union[Callable[[Tuple[int, int]], HTMLResponse], None] = None,
     **kwargs: Any
-) -> FastAPI:
+) -> FastAPIT:
     docs_url = kwargs.pop('docs_url', None)
     redoc_url = kwargs.pop('redoc_url', None)
-    versioned_app = FastAPI(
+    versioned_app = app.__class__(
         title=app.title,
         description=app.description,
         version=semver,

--- a/fastapi_versionizer/versionizer.py
+++ b/fastapi_versionizer/versionizer.py
@@ -124,7 +124,10 @@ def versionize(
 
         for route in version_remove_route_mapping[version]:
             for unique_key in _get_unique_route_keys(route):
-                unique_routes.pop(unique_key, None)
+                if unique_key in unique_routes:
+                    del unique_routes[unique_key]
+                else:
+                    raise ValueError(f'Route {unique_key!r} can\'t be removed in version {version}')
 
         versioned_app = _build_versioned_app(
             app=app,

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -9,24 +9,41 @@ class TestSimple(TestCase):
     def test_simple(self) -> None:
         test_client = TestClient(app)
 
-        self.assertListEqual([(1, 0), (2, 0)], versions)
+        self.assertListEqual([(1, 0), (2, 0), (3, 0), (4, 0)], versions)
         self.assertEqual(404, test_client.get('/').status_code)
         self.assertEqual(404, test_client.get('/docs').status_code)
         self.assertEqual(404, test_client.get('/redoc').status_code)
         self.assertEqual(200, test_client.get('/openapi.json').status_code)
         self.assertEqual(200, test_client.get('/versions').status_code)
+
         self.assertEqual(200, test_client.get('/v1/docs').status_code)
         self.assertEqual(200, test_client.get('/v1/redoc').status_code)
         self.assertEqual(200, test_client.get('/v1/openapi.json').status_code)
         self.assertEqual(200, test_client.post('/v1/do_something', json={'something': 'something'}).status_code)
         self.assertEqual(200, test_client.post('/v1/do_something_else').status_code)
         self.assertEqual(404, test_client.post('/v1/do_something_new').status_code)
+
         self.assertEqual(200, test_client.get('/v2/docs').status_code)
         self.assertEqual(200, test_client.get('/v2/redoc').status_code)
         self.assertEqual(200, test_client.get('/v2/openapi.json').status_code)
         self.assertEqual(200, test_client.post('/v2/do_something').status_code)
         self.assertEqual(200, test_client.post('/v2/do_something_else').status_code)
         self.assertEqual(200, test_client.post('/v2/do_something_new').status_code)
+
+        self.assertEqual(200, test_client.get('/v3/docs').status_code)
+        self.assertEqual(200, test_client.get('/v3/redoc').status_code)
+        self.assertEqual(200, test_client.get('/v3/openapi.json').status_code)
+        self.assertEqual(404, test_client.post('/v3/do_something').status_code)
+        self.assertEqual(200, test_client.post('/v3/do_something_else').status_code)
+        self.assertEqual(404, test_client.post('/v3/do_something_new').status_code)
+
+        self.assertEqual(200, test_client.get('/v4/docs').status_code)
+        self.assertEqual(200, test_client.get('/v4/redoc').status_code)
+        self.assertEqual(200, test_client.get('/v4/openapi.json').status_code)
+        self.assertEqual(200, test_client.post('/v4/do_something').status_code)
+        self.assertEqual(200, test_client.post('/v4/do_something_else').status_code)
+        self.assertEqual(404, test_client.post('/v4/do_something_new').status_code)
+
         self.assertEqual(404, test_client.get('/latest/docs').status_code)
         self.assertEqual(404, test_client.get('/latest/redoc').status_code)
         self.assertEqual(404, test_client.get('/latest/openapi.json').status_code)
@@ -35,9 +52,10 @@ class TestSimple(TestCase):
         self.assertEqual(404, test_client.get('/latest/do_something_new').status_code)
 
         self.assertDictEqual(
-            {'versions': [{'version': '1.0'}, {'version': '2.0'}]},
+            {'versions': [{'version': '1.0'}, {'version': '2.0'}, {'version': '3.0'}, {'version': '4.0'}]},
             test_client.get('/versions').json()
         )
+
         self.assertDictEqual(
             {'something': 'something'},
             test_client.post('/v1/do_something', json={'something': 'something'}).json()
@@ -46,6 +64,7 @@ class TestSimple(TestCase):
             {'message': 'something else'},
             test_client.post('/v1/do_something_else').json()
         )
+
         self.assertDictEqual(
             {'message': 'something'},
             test_client.post('/v2/do_something').json()
@@ -57,4 +76,9 @@ class TestSimple(TestCase):
         self.assertDictEqual(
             {'message': 'something new'},
             test_client.post('/v2/do_something_new').json()
+        )
+
+        self.assertDictEqual(
+            {'message': 'something re-added'},
+            test_client.post('/v4/do_something').json()
         )


### PR DESCRIPTION
- Versioned app now uses the same FastAPI class as the original app.
- Routes can now be removed with `@api_version_remove` decorator.