### PR TITLE
Added missing import to __init__.py

### DIFF
--- a/fastapi_versionizer/__init__.py
+++ b/fastapi_versionizer/__init__.py
@@ -1,6 +1,7 @@
-from .versionizer import versionize, api_version
+from .versionizer import versionize, api_version, api_version_remove
 
 __all__ = [
     'versionize',
     'api_version',
+    'api_version_remove',
 ]


### PR DESCRIPTION
`from fastapi_versionizer import api_version_remove` did not work, because `api_version_remove` was not imported in `__init__.py`