### PR TITLE
Now using natural sorting for routes for sorted_routes=True

### DIFF
--- a/examples/sorted.py
+++ b/examples/sorted.py
@@ -16,46 +16,57 @@ class TestModel(BaseModel):
     something: str
 
 
-@app.post('/xxx_do_something', tags=['Something'], response_model=TestModel)
+@app.post('/1', tags=['Something'], response_model=TestModel)
 async def do_something(test: TestModel) -> Any:
     return test
 
 
-@app.post('/bbb_do_something_else', tags=['Something Else'])
+@app.post('/2', tags=['Something Else'])
 async def do_something_else() -> Any:
     return {'message': 'something else'}
 
 
 @api_version(2)
-@app.post('/xxx_do_something', tags=['Something'])
+@app.post('/1', tags=['Something'])
 async def do_something_v2() -> Any:
     return {'message': 'something'}
 
 
-@api_version(2)
-@app.post('/aaa_do_something_new', tags=['Something New'])
+@api_version(10)
+@app.post('/10', tags=['Something New'])
 async def do_something_new() -> Any:
     return {'message': 'something new'}
 
 
-@api_version(2, 1)
-@app.post('/aaa_do_something_new', tags=['Something New'])
+@api_version(10, 1)
+@app.post('/10', tags=['Something New'])
 async def do_something_newer() -> Any:
     return {'message': 'something newer'}
 
 
+@api_version(10, 1)
+@app.post('/10/0', tags=['Something Newe'])
+async def do_something_newest() -> Any:
+    return {'message': 'something newest'}
+
+
 '''
 - Notes:
-    - "/v1.0/docs" and "/v2.0/docs" pages are generated, because `docs_url` is given
+    - "/v1.0/docs", "/v2.0/docs", "/v10.0/docs", and "/v10.1/docs" pages are generated, because `docs_url` is given
     - "/versions" is automatically generated
 
 - We test and seek the following endpoints:
-    - /v1.0/xxx_do_something
-    - /v1.0/bbb_do_something_else
-    - /v2.0/xxx_do_something
-    - /v2.0/bbb_do_something_else
-    - /v2.0/aaa_do_something_new
-    - /v2.1/aaa_do_something_new
+    - /v1.0/1
+    - /v1.0/2
+    - /v2.0/1
+    - /v2.0/2
+    - /v10.0/1
+    - /v10.0/2
+    - /v10.0/10
+    - /v10.1/1
+    - /v10.1/2
+    - /v10.1/10
+    - /v10.1/10/0
 '''
 versions = versionize(
     app=app,

--- a/fastapi_versionizer/versionizer.py
+++ b/fastapi_versionizer/versionizer.py
@@ -5,7 +5,7 @@ from fastapi.responses import HTMLResponse
 from fastapi.routing import APIRoute, Mount
 from starlette.routing import BaseRoute, Route, WebSocketRoute
 from pydantic import BaseModel
-from natsort import os_sorted
+from natsort import natsorted
 
 CallableT = TypeVar('CallableT', bound=Callable[..., Any])
 FastAPIT = TypeVar('FastAPIT', bound=FastAPI)
@@ -174,7 +174,7 @@ def versionize(
             app=app,
             version=version,
             semver=semver,
-            unique_routes=dict(os_sorted(unique_routes.items())) if sorted_routes else unique_routes,
+            unique_routes=dict(natsorted(unique_routes.items())) if sorted_routes else unique_routes,
             prefix=prefix,
             get_openapi=get_openapi,
             get_docs=get_docs,
@@ -192,7 +192,7 @@ def versionize(
             app=app,
             version=version,
             semver=semver,
-            unique_routes=dict(os_sorted(unique_routes.items())) if sorted_routes else unique_routes,
+            unique_routes=dict(natsorted(unique_routes.items())) if sorted_routes else unique_routes,
             prefix=latest_prefix,
             get_openapi=get_openapi,
             get_docs=get_docs,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 fastapi>=0.86.0
+natsort==8.*

--- a/tests/test_sorted.py
+++ b/tests/test_sorted.py
@@ -9,51 +9,65 @@ class TestSorted(TestCase):
     def test_sorted(self) -> None:
         test_client = TestClient(app)
 
-        self.assertListEqual([(1, 0), (2, 0), (2, 1)], versions)
+        self.assertListEqual([(1, 0), (2, 0), (10, 0), (10, 1)], versions)
         self.assertEqual(404, test_client.get('/').status_code)
 
         self.assertEqual(200, test_client.get('/v1.0/openapi.json').status_code)
-        self.assertEqual(200, test_client.post('/v1.0/xxx_do_something', json={'something': 'something'}).status_code)
-        self.assertEqual(200, test_client.post('/v1.0/bbb_do_something_else').status_code)
-        self.assertEqual(404, test_client.post('/v1.0/aaa_do_something_new').status_code)
+        self.assertEqual(200, test_client.post('/v1.0/1', json={'something': 'something'}).status_code)
+        self.assertEqual(200, test_client.post('/v1.0/2').status_code)
+        self.assertEqual(404, test_client.post('/v1.0/10').status_code)
 
         self.assertEqual(200, test_client.get('/v2.0/openapi.json').status_code)
-        self.assertEqual(200, test_client.post('/v2.0/xxx_do_something').status_code)
-        self.assertEqual(200, test_client.post('/v2.0/bbb_do_something_else').status_code)
-        self.assertEqual(200, test_client.post('/v2.0/aaa_do_something_new').status_code)
+        self.assertEqual(200, test_client.post('/v2.0/1').status_code)
+        self.assertEqual(200, test_client.post('/v2.0/2').status_code)
+        self.assertEqual(404, test_client.post('/v2.0/10').status_code)
 
-        self.assertEqual(200, test_client.post('/v2.1/aaa_do_something_new').status_code)
+        self.assertEqual(200, test_client.get('/v10.0/openapi.json').status_code)
+        self.assertEqual(200, test_client.post('/v10.0/1').status_code)
+        self.assertEqual(200, test_client.post('/v10.0/2').status_code)
+        self.assertEqual(200, test_client.post('/v10.0/10').status_code)
+
+        self.assertEqual(200, test_client.get('/v10.1/openapi.json').status_code)
+        self.assertEqual(200, test_client.post('/v10.1/1').status_code)
+        self.assertEqual(200, test_client.post('/v10.1/2').status_code)
+        self.assertEqual(200, test_client.post('/v10.1/10').status_code)
+        self.assertEqual(200, test_client.post('/v10.1/10/0').status_code)
 
         self.assertDictEqual(
             {
                 'title': 'My Versioned API (route-path sorted)',
                 'description': 'Look, I can version my APIs and sort the route-paths!',
-                'version': '2.1'
+                'version': '10.1'
             },
-            test_client.get('/v2.1/openapi.json').json()['info']
+            test_client.get('/v10.1/openapi.json').json()['info']
         )
 
         self.assertListEqual(
-            ['/bbb_do_something_else', '/xxx_do_something'],
+            ['/1', '/2'],
             list(test_client.get('/v1.0/openapi.json').json()['paths'].keys())
         )
 
         self.assertListEqual(
-            ['/aaa_do_something_new', '/bbb_do_something_else', '/xxx_do_something'],
+            ['/1', '/2'],
             list(test_client.get('/v2.0/openapi.json').json()['paths'].keys())
         )
 
         self.assertListEqual(
-            ['/aaa_do_something_new', '/bbb_do_something_else', '/xxx_do_something'],
+            ['/1', '/2', '/10', '/10/0'],
             list(test_client.get('/latest/openapi.json').json()['paths'].keys())
         )
 
         self.assertListEqual(
-            ['/aaa_do_something_new', '/bbb_do_something_else', '/xxx_do_something'],
-            list(test_client.get('/v2.1/openapi.json').json()['paths'].keys())
+            ['/1', '/2', '/10'],
+            list(test_client.get('/v10.0/openapi.json').json()['paths'].keys())
+        )
+
+        self.assertListEqual(
+            ['/1', '/2', '/10', '/10/0'],
+            list(test_client.get('/v10.1/openapi.json').json()['paths'].keys())
         )
 
         self.assertEqual(
             'Do Something Newer',
-            test_client.get('/v2.1/openapi.json').json()['paths']['/aaa_do_something_new']['post']['summary']
+            test_client.get('/v10.1/openapi.json').json()['paths']['/10']['post']['summary']
         )


### PR DESCRIPTION
## Pull Request Checklist

- [X] Make sure to read the contributor guide [here](https://github.com/alexschimpf/fastapi-versionizer/tree/main/CONTRIBUTE.md).
- [X] Make sure you are making a pull request against the main branch.
- [X] Make sure your pull request title matches the requested format.
- [X] Make sure to lint, type-check, and run unit and API tests.

## Description
When sorted_routes=True, we have not been using "natural" sorting, but rather alphanuemeric sorting.
Example:
```
Routes:
GET /1
POST /1
GET /10
POST /10
GET /10/1
POST /2

These routes would be assigned the following string keys by `_get_unique_route_keys`:
/1|GET
/1|POST
/10|GET
/10|POST
/10/1|GET
/2|POST

We'd then use `sorted` on these keys, resulting in the following order:
/10/1|GET => GET /10/1
/10|GET    => GET /10
/10|POST. => POST /10
/1|GET.      => GET /1
/1|POST.   => POST /1
/2|POST.   => POST /2
```

This is not the behavior a human would typically expect.

Solution:
- I'm using tuple keys in `_get_unique_route_keys`, so that route path lengths don't cause issues with the concatenated HTTP method.
- I'm using the `natsorted` lib to naturally do the sorting instead of `sorted`. This will sort numbers in route paths (an atypical scenario) as expected. 

New result:
```
('/1', 'GET')     => GET /1
('/1', 'POST')   => POST /1
('/2', 'POST')  => POST /2
('/10', 'GET')   => GET /10
('/10', 'POST') => POST /10
('/10/1', 'GET') => GET /10/1
```

If needed, a separate PR can address a new feature to allow for custom sorting of routes.

