### PR TITLE
Fixed issue where custom latest_prefix wasn't getting passed to callback correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ An APIRouter will be created for each version, with the URL prefix defined by th
   - Default version used if a route is not annotated with @api_version.
 - <b>latest_prefix</b>
   - If this is given, the routes in your latest version will be a given a separate prefix alias.
-  - For example, if your latest version is 1, and you have routes: "GET /v1/a" and "POST /v1/b", then "GET /latest/a" and "POST /latest/b" will also be added.
+  - For example, if latest_prefix='latest', latest version is 1, and you have routes: "GET /v1/a" and "POST /v1/b", then "GET /latest/a" and "POST /latest/b" will also be added.
 - <b>include_main_docs</b>
   - If True, docs page(s) will be created at the root, with all versioned routes included
 - <b>include_main_openapi_route</b>

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,15 +1,15 @@
 module.exports = {
     rules: {
         'subject-min-length': [2, 'always', 10],
-        'subject-max-length': [2, 'always', 80],
+        'subject-max-length': [2, 'always', 120],
         'subject-case': [2, 'always', 'sentence-case'],
         'subject-full-stop': [2, 'never', '.'],
         'body-min-length': [2, 'always', 0],
-        'body-max-line-length': [2, 'always', 100],
+        'body-max-line-length': [2, 'always', 120],
         'body-case': [2, 'always', 'sentence-case'],
         'body-full-stop': [2, 'always', '.'],
         'footer-min-length': [2, 'always', 0],
-        'footer-max-line-length': [2, 'always', 100],
+        'footer-max-line-length': [2, 'always', 120],
         'type-enum': [2, 'always', [
             'breaking', 'deps', 'chore', 'ci', 'docs', 'feat', 'fix', 'perf', 'refactor', 'style', 'test'
          ]],


### PR DESCRIPTION
## Pull Request Checklist

- [X] Make sure to read the contributor guide [here](https://github.com/alexschimpf/fastapi-versionizer/tree/main/CONTRIBUTE.md).
- [X] Make sure you are making a pull request against the main branch.
- [X] Make sure your pull request title matches the requested format.
- [X] Make sure to lint, type-check, and run unit and API tests.

## Description
I had "/latest" hardcoded when passed to callback function.
I also added some unrelated minor updates around empty-string vs. None checks.
