### PR TITLE
feat: Added OpenAPI metadata to version docs (#38)

### DIFF
--- a/examples/simple.py
+++ b/examples/simple.py
@@ -41,7 +41,9 @@ app = FastAPI(
     title='test',
     docs_url='/swagger',
     openapi_url='/api_schema.json',
-    redoc_url=None
+    redoc_url=None,
+    description='Simple example of FastAPI Versionizer.',
+    terms_of_service='https://github.com/alexschimpf/fastapi-versionizer'
 )
 users_router = APIRouter(
     prefix='/users',

--- a/fastapi_versionizer/versionizer.py
+++ b/fastapi_versionizer/versionizer.py
@@ -216,28 +216,21 @@ class Versionizer:
         if self._include_version_openapi_route and self._app.openapi_url is not None:
             @router.get(self._app.openapi_url, include_in_schema=False)
             async def get_openapi() -> Any:
+                openapi_params: Dict[str, Any] = {
+                    'title': title,
+                    'version': version_str,
+                    'routes': router.routes,
+                    'description': self._app.description,
+                    'terms_of_service': self._app.terms_of_service,
+                    'contact': self._app.contact,
+                    'license_info': self._app.license_info
+                }
+
                 if hasattr(self._app, 'summary'):
-                    # summary is available since OpenAPI 3.1.0, FastAPI 0.99.0
-                    return fastapi.openapi.utils.get_openapi(
-                        title=title,
-                        version=version_str,
-                        summary=self._app.summary,
-                        description=self._app.description,
-                        routes=router.routes,
-                        terms_of_service=self._app.terms_of_service,
-                        contact=self._app.contact,
-                        license_info=self._app.license_info
-                    )
-                else:
-                    return fastapi.openapi.utils.get_openapi(
-                        title=title,
-                        version=version_str,
-                        description=self._app.description,
-                        routes=router.routes,
-                        terms_of_service=self._app.terms_of_service,
-                        contact=self._app.contact,
-                        license_info=self._app.license_info
-                    )
+                    # Available since OpenAPI 3.1.0, FastAPI 0.99.0
+                    openapi_params['summary'] = self._app.summary
+
+                return fastapi.openapi.utils.get_openapi(**openapi_params)
 
         if self._include_version_docs and self._app.docs_url is not None and self._app.openapi_url is not None:
             @router.get(self._app.docs_url, include_in_schema=False)

--- a/fastapi_versionizer/versionizer.py
+++ b/fastapi_versionizer/versionizer.py
@@ -216,11 +216,28 @@ class Versionizer:
         if self._include_version_openapi_route and self._app.openapi_url is not None:
             @router.get(self._app.openapi_url, include_in_schema=False)
             async def get_openapi() -> Any:
-                return fastapi.openapi.utils.get_openapi(
-                    title=title,
-                    version=version_str,
-                    routes=router.routes
-                )
+                if hasattr(self._app, 'summary'):
+                    # summary is available since OpenAPI 3.1.0, FastAPI 0.99.0
+                    return fastapi.openapi.utils.get_openapi(
+                        title=title,
+                        version=version_str,
+                        summary=self._app.summary,
+                        description=self._app.description,
+                        routes=router.routes,
+                        terms_of_service=self._app.terms_of_service,
+                        contact=self._app.contact,
+                        license_info=self._app.license_info
+                    )
+                else:
+                    return fastapi.openapi.utils.get_openapi(
+                        title=title,
+                        version=version_str,
+                        description=self._app.description,
+                        routes=router.routes,
+                        terms_of_service=self._app.terms_of_service,
+                        contact=self._app.contact,
+                        license_info=self._app.license_info
+                    )
 
         if self._include_version_docs and self._app.docs_url is not None and self._app.openapi_url is not None:
             @router.get(self._app.docs_url, include_in_schema=False)

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -141,6 +141,8 @@ class TestSimpleExample(TestCase):
                 'openapi': '3.1.0',
                 'info': {
                     'title': 'test',
+                    'description': 'Simple example of FastAPI Versionizer.',
+                    'termsOfService': 'https://github.com/alexschimpf/fastapi-versionizer',
                     'version': '0.1.0'
                 },
                 'paths': {
@@ -931,6 +933,8 @@ class TestSimpleExample(TestCase):
                 'openapi': '3.1.0',
                 'info': {
                     'title': 'test - v1',
+                    'description': 'Simple example of FastAPI Versionizer.',
+                    'termsOfService': 'https://github.com/alexschimpf/fastapi-versionizer',
                     'version': 'v1'
                 },
                 'paths': {
@@ -1269,6 +1273,8 @@ class TestSimpleExample(TestCase):
                 'openapi': '3.1.0',
                 'info': {
                     'title': 'test - v2',
+                    'description': 'Simple example of FastAPI Versionizer.',
+                    'termsOfService': 'https://github.com/alexschimpf/fastapi-versionizer',
                     'version': 'v2'
                 },
                 'paths': {
@@ -1569,6 +1575,8 @@ class TestSimpleExample(TestCase):
                 'openapi': '3.1.0',
                 'info': {
                     'title': 'test - v2',
+                    'description': 'Simple example of FastAPI Versionizer.',
+                    'termsOfService': 'https://github.com/alexschimpf/fastapi-versionizer',
                     'version': 'v2'
                 },
                 'paths': {


### PR DESCRIPTION
## Pull Request Checklist

- [x] Make sure to read the contributor guide [here](https://github.com/alexschimpf/fastapi-versionizer/tree/main/CONTRIBUTE.md).
- [x] Make sure you are making a pull request against the main branch.
- [x] Make sure your pull request title matches the requested format.
- [x] Make sure to lint, type-check, and run unit and API tests.

## Description
closes #38

My first try looked like this:
```python
            async def get_openapi() -> Any:
                openapi_args = {
                    'title': title,
                    'version': version_str,
                    'routes': router.routes,
                    'description': self._app.description,
                    'terms_of_service': self._app.terms_of_service,
                    'contact': self._app.contact,
                    'license_info': self._app.license_info,
                }
                if hasattr(self._app, 'summary'):
                    # Available since OpenAPI 3.1.0, FastAPI 0.99.0
                    openapi_args['summary'] = self._app.summary
                return fastapi.openapi.utils.get_openapi(**openapi_args)
```
But mypy didn't like that:
```
fastapi_versionizer/versionizer.py:231: error: Argument 1 to "get_openapi" has incompatible type "**dict[str, Sequence[object] | dict[str, str | Any] | None]"; expected "str"  [arg-type]
fastapi_versionizer/versionizer.py:231: error: Argument 1 to "get_openapi" has incompatible type "**dict[str, Sequence[object] | dict[str, str | Any] | None]"; expected "str | None"  [arg-type]
fastapi_versionizer/versionizer.py:231: error: Argument 1 to "get_openapi" has incompatible type "**dict[str, Sequence[object] | dict[str, str | Any] | None]"; expected "Sequence[BaseRoute]"  [arg-type]
fastapi_versionizer/versionizer.py:231: error: Argument 1 to "get_openapi" has incompatible type "**dict[str, Sequence[object] | dict[str, str | Any] | None]"; expected "Sequence[BaseRoute] | None"  [arg-type]
fastapi_versionizer/versionizer.py:231: error: Argument 1 to "get_openapi" has incompatible type "**dict[str, Sequence[object] | dict[str, str | Any] | None]"; expected "list[dict[str, Any]] | None"  [arg-type]
fastapi_versionizer/versionizer.py:231: error: Argument 1 to "get_openapi" has incompatible type "**dict[str, Sequence[object] | dict[str, str | Any] | None]"; expected "list[dict[str, str | Any]] | None"  [arg-type]
fastapi_versionizer/versionizer.py:231: error: Argument 1 to "get_openapi" has incompatible type "**dict[str, Sequence[object] | dict[str, str | Any] | None]"; expected "dict[str, str | Any] | None"  [arg-type]
fastapi_versionizer/versionizer.py:231: note: "Dict" is invariant -- see https://mypy.readthedocs.io/en/stable/common_issues.html#variance
fastapi_versionizer/versionizer.py:231: note: Consider using "Mapping" instead, which is covariant in the value type
fastapi_versionizer/versionizer.py:231: error: Argument 1 to "get_openapi" has incompatible type "**dict[str, Sequence[object] | dict[str, str | Any] | None]"; expected "bool"  [arg-type]
Found 8 errors in 1 file (checked 9 source files)
```
So this solution is a bit easier. I hope you still like it. 😃 