### PR TITLE
Add lifespan support

### DIFF
--- a/examples/with_lifespan.py
+++ b/examples/with_lifespan.py
@@ -1,0 +1,65 @@
+# mypy: disable-error-code="no-any-return"
+# flake8: noqa: A003
+
+from contextlib import asynccontextmanager
+from fastapi import FastAPI, APIRouter
+
+from fastapi_versionizer.versionizer import Versionizer, api_version
+
+
+class TestLifeSpan:
+    initialized = False
+
+    @classmethod
+    def init(cls) -> None:
+        cls.initialized = True
+
+
+@asynccontextmanager
+async def lifespan(_: FastAPI):
+    try:
+        TestLifeSpan.init()
+        yield
+    finally:
+        pass
+
+
+app = FastAPI(
+    title='test',
+    docs_url='/swagger',
+    openapi_url='/api_schema.json',
+    redoc_url=None,
+    lifespan=lifespan
+)
+status_router = APIRouter(
+    prefix='/status',
+    tags=['Status']
+)
+
+
+@api_version(1)
+@status_router.get('', deprecated=True)
+def get_v1_status() -> str:
+    if not TestLifeSpan.initialized:
+        raise Exception('Lifespan not initialized')
+    return 'Ok'
+
+
+@api_version(2)
+@status_router.get('')
+def get_v2_status() -> str:
+    if not TestLifeSpan.initialized:
+        raise Exception('Lifespan not initialized')
+    return 'Ok'
+
+
+app.include_router(status_router)
+
+app, versions = Versionizer(
+    app=app,
+    prefix_format='/v{major}',
+    semantic_version_format='{major}',
+    latest_prefix='/latest',
+    include_versions_route=True,
+    sort_routes=True
+).versionize()

--- a/examples/with_lifespan.py
+++ b/examples/with_lifespan.py
@@ -2,6 +2,7 @@
 # flake8: noqa: A003
 
 from contextlib import asynccontextmanager
+from typing import AsyncGenerator
 from fastapi import FastAPI, APIRouter
 
 from fastapi_versionizer.versionizer import Versionizer, api_version
@@ -16,7 +17,7 @@ class TestLifeSpan:
 
 
 @asynccontextmanager
-async def lifespan(_: FastAPI):
+async def lifespan(_: FastAPI) -> AsyncGenerator[None, None]:
     try:
         TestLifeSpan.init()
         yield

--- a/fastapi_versionizer/versionizer.py
+++ b/fastapi_versionizer/versionizer.py
@@ -88,7 +88,6 @@ class Versionizer:
                 - Version path prefix
         """
         self._app = app
-        self._lifespan_context = app.router.lifespan_context
         self._prefix_format = prefix_format
         self._semantic_version_format = semantic_version_format
         self._default_version = default_version
@@ -141,8 +140,6 @@ class Versionizer:
 
         if not self._include_main_docs or not self._include_main_openapi_route:
             self._remove_docs_and_openapi(versioned_app=versioned_app)
-
-        versioned_app.router.lifespan_context = self._lifespan_context
 
         return versioned_app, versions
 
@@ -318,7 +315,9 @@ class Versionizer:
         kwargs.pop('router')
         for _ in range(10000):
             try:
-                return app.__class__(**kwargs)
+                cloned_app = app.__class__(**kwargs)
+                cloned_app.router.lifespan_context = app.router.lifespan_context
+                return cloned_app
             except TypeError as e:
                 e_str = str(e)
                 key_start = e_str.index("'") + 1

--- a/fastapi_versionizer/versionizer.py
+++ b/fastapi_versionizer/versionizer.py
@@ -88,6 +88,7 @@ class Versionizer:
                 - Version path prefix
         """
         self._app = app
+        self._lifespan_context = app.router.lifespan_context
         self._prefix_format = prefix_format
         self._semantic_version_format = semantic_version_format
         self._default_version = default_version
@@ -140,6 +141,8 @@ class Versionizer:
 
         if not self._include_main_docs or not self._include_main_openapi_route:
             self._remove_docs_and_openapi(versioned_app=versioned_app)
+
+        versioned_app.router.lifespan_context = self._lifespan_context
 
         return versioned_app, versions
 

--- a/tests/test_with_lifespan.py
+++ b/tests/test_with_lifespan.py
@@ -1,0 +1,35 @@
+from fastapi.testclient import TestClient
+
+from unittest import TestCase
+from examples.with_lifespan import app, versions
+
+
+class TestWithLifespanExample(TestCase):
+
+    def test_with_lifespan_example(self) -> None:
+        with TestClient(app) as test_client:
+
+            self.assertListEqual([(1, 0), (2, 0)], versions)
+
+            # versions route
+            self.assertDictEqual(
+                {
+                    'versions': [
+                        {
+                            'version': '1',
+                            'openapi_url': '/v1/api_schema.json',
+                            'swagger_url': '/v1/swagger'
+                        },
+                        {
+                            'version': '2',
+                            'openapi_url': '/v2/api_schema.json',
+                            'swagger_url': '/v2/swagger',
+                        }
+                    ]
+                },
+                test_client.get('/versions').json()
+            )
+
+            # status route
+            self.assertEqual(200, test_client.get('/v1/status').status_code)
+            self.assertEqual(200, test_client.get('/v2/status').status_code)


### PR DESCRIPTION
Added support for lifespan functions. Previously it wasn’t working because we are removing default router from kwargs while cloning the app. 