### PR TITLE
fix: Fixed issue with missing root_path for versioned doc pages

### DIFF
--- a/examples/with_root_path.py
+++ b/examples/with_root_path.py
@@ -7,8 +7,9 @@ app = FastAPI(
     title='test',
     docs_url='/swagger',
     root_path='/api',
+    root_path_in_servers=True,
     openapi_url='/api_schema.json',
-    redoc_url=None,
+    redoc_url=None
 )
 
 

--- a/examples/with_root_path.py
+++ b/examples/with_root_path.py
@@ -24,7 +24,7 @@ def get_status_v2() -> str:
     return 'Okv2'
 
 
-app, versions = Versionizer(
+versions = Versionizer(
     app=app,
     prefix_format='/v{major}',
     semantic_version_format='{major}',

--- a/examples/with_root_path.py
+++ b/examples/with_root_path.py
@@ -1,0 +1,34 @@
+from fastapi import FastAPI
+
+from fastapi_versionizer.versionizer import Versionizer, api_version
+
+
+app = FastAPI(
+    title='test',
+    docs_url='/swagger',
+    root_path='/api',
+    openapi_url='/api_schema.json',
+    redoc_url=None,
+)
+
+
+@api_version(1)
+@app.get('/status', tags=['Status'])
+def get_status_v1() -> str:
+    return 'Okv1'
+
+
+@api_version(2)
+@app.get('/status', tags=['Status'])
+def get_status_v2() -> str:
+    return 'Okv2'
+
+
+app, versions = Versionizer(
+    app=app,
+    prefix_format='/v{major}',
+    semantic_version_format='{major}',
+    latest_prefix='/latest',
+    include_versions_route=True,
+    sort_routes=True
+).versionize()

--- a/fastapi_versionizer/versionizer.py
+++ b/fastapi_versionizer/versionizer.py
@@ -230,13 +230,16 @@ class Versionizer:
                     # Available since OpenAPI 3.1.0, FastAPI 0.99.0
                     openapi_params['summary'] = self._app.summary
 
+                if self._app.root_path != '':
+                    openapi_params['servers'] = [{'url': self._app.root_path.rstrip('/')}]
+
                 return fastapi.openapi.utils.get_openapi(**openapi_params)
 
         if self._include_version_docs and self._app.docs_url is not None and self._app.openapi_url is not None:
             @router.get(self._app.docs_url, include_in_schema=False)
             async def get_docs() -> HTMLResponse:
                 return get_swagger_ui_html(
-                    openapi_url=f'{version_prefix}{self._app.openapi_url}',
+                    openapi_url=f'{self._app.root_path.rstrip("/")}{version_prefix}{self._app.openapi_url}',
                     title=title,
                     swagger_ui_parameters=self._app.swagger_ui_parameters
                 )
@@ -245,7 +248,7 @@ class Versionizer:
             @router.get(self._app.redoc_url, include_in_schema=False)
             async def get_redoc() -> HTMLResponse:
                 return get_redoc_html(
-                    openapi_url=f'{version_prefix}{self._app.openapi_url}',
+                    openapi_url=f'{self._app.root_path.rstrip("/")}{version_prefix}{self._app.openapi_url}',
                     title=title
                 )
 
@@ -266,13 +269,22 @@ class Versionizer:
                 }
 
                 if self._include_version_openapi_route and versioned_app.openapi_url is not None:
-                    version_model['openapi_url'] = f'{version_prefix}{versioned_app.openapi_url}'
+                    version_model['openapi_url'] = (
+                        f'{self._app.root_path.rstrip("/")}'
+                        f'{version_prefix}{versioned_app.openapi_url}'
+                    )
 
                 if self._include_version_docs and versioned_app.docs_url is not None:
-                    version_model['swagger_url'] = f'{version_prefix}{versioned_app.docs_url}'
+                    version_model['swagger_url'] = (
+                        f'{self._app.root_path.rstrip("/")}'
+                        f'{version_prefix}{versioned_app.docs_url}'
+                    )
 
                 if self._include_version_docs and versioned_app.redoc_url is not None:
-                    version_model['redoc_url'] = f'{version_prefix}{versioned_app.redoc_url}'
+                    version_model['redoc_url'] = (
+                        f'{self._app.root_path.rstrip("/")}'
+                        f'{version_prefix}{versioned_app.redoc_url}'
+                    )
 
                 version_models.append(version_model)
 

--- a/fastapi_versionizer/versionizer.py
+++ b/fastapi_versionizer/versionizer.py
@@ -224,15 +224,13 @@ class Versionizer:
                     'description': self._app.description,
                     'terms_of_service': self._app.terms_of_service,
                     'contact': self._app.contact,
-                    'license_info': self._app.license_info
+                    'license_info': self._app.license_info,
+                    'servers': self._app.servers
                 }
 
                 if hasattr(self._app, 'summary'):
                     # Available since OpenAPI 3.1.0, FastAPI 0.99.0
                     openapi_params['summary'] = self._app.summary
-
-                if self._app.root_path:
-                    openapi_params['servers'] = [{'url': self._app.root_path.rstrip('/')}]
 
                 return fastapi.openapi.utils.get_openapi(**openapi_params)
 

--- a/tests/test_with_root_path.py
+++ b/tests/test_with_root_path.py
@@ -1,0 +1,265 @@
+from fastapi.testclient import TestClient
+
+from unittest import TestCase
+from examples.with_root_path import app, versions
+
+
+class TestWitRootPathExample(TestCase):
+
+    def test_with_root_path_example(self) -> None:
+        test_client = TestClient(app)
+
+        self.assertListEqual([(1, 0), (2, 0)], versions)
+
+        # versions route
+        self.assertDictEqual(
+            {
+                'versions': [
+                    {
+                        'version': '1',
+                        'openapi_url': '/api/v1/api_schema.json',
+                        'swagger_url': '/api/v1/swagger'
+                    },
+                    {
+                        'version': '2',
+                        'openapi_url': '/api/v2/api_schema.json',
+                        'swagger_url': '/api/v2/swagger',
+                    }
+                ]
+            },
+            test_client.get('/versions').json()
+        )
+
+        self.assertEqual('"Okv1"', test_client.get('/v1/status').text)
+        self.assertEqual('"Okv2"', test_client.get('/v2/status').text)
+        self.assertEqual('"Okv2"', test_client.get('/latest/status').text)
+
+        # docs
+        self.assertEqual(200, test_client.get('/swagger').status_code)
+        self.assertEqual(200, test_client.get('/v1/swagger').status_code)
+        self.assertEqual(200, test_client.get('/v2/swagger').status_code)
+        self.assertEqual(200, test_client.get('/latest/swagger').status_code)
+
+        # openapi
+        self.assertDictEqual(
+            {
+                'openapi': '3.1.0',
+                'info': {
+                    'title': 'test',
+                    'version': '0.1.0'
+                },
+                'servers': [
+                    {
+                        'url': '/api'
+                    }
+                ],
+                'paths': {
+                    '/v1/status': {
+                        'get': {
+                            'tags': [
+                                'Status'
+                            ],
+                            'summary': 'Get Status V1',
+                            'operationId': 'get_status_v1_v1_status_get',
+                            'responses': {
+                                '200': {
+                                    'description': 'Successful Response',
+                                    'content': {
+                                        'application/json': {
+                                            'schema': {
+                                                'type': 'string',
+                                                'title': 'Response Get Status V1 V1 Status Get'
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    '/v2/status': {
+                        'get': {
+                            'tags': [
+                                'Status'
+                            ],
+                            'summary': 'Get Status V2',
+                            'operationId': 'get_status_v2_v2_status_get',
+                            'responses': {
+                                '200': {
+                                    'description': 'Successful Response',
+                                    'content': {
+                                        'application/json': {
+                                            'schema': {
+                                                'type': 'string',
+                                                'title': 'Response Get Status V2 V2 Status Get'
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    '/latest/status': {
+                        'get': {
+                            'tags': [
+                                'Status'
+                            ],
+                            'summary': 'Get Status V2',
+                            'operationId': 'get_status_v2_latest_status_get',
+                            'responses': {
+                                '200': {
+                                    'description': 'Successful Response',
+                                    'content': {
+                                        'application/json': {
+                                            'schema': {
+                                                'type': 'string',
+                                                'title': 'Response Get Status V2 Latest Status Get'
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    '/versions': {
+                        'get': {
+                            'tags': [
+                                'Versions'
+                            ],
+                            'summary': 'Get Versions',
+                            'operationId': 'get_versions_versions_get',
+                            'responses': {
+                                '200': {
+                                    'description': 'Successful Response',
+                                    'content': {
+                                        'application/json': {
+                                            'schema': {
+                                                'type': 'object',
+                                                'title': 'Response Get Versions Versions Get'
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            test_client.get('/api_schema.json').json()
+        )
+        self.assertDictEqual(
+            {
+                'openapi': '3.1.0',
+                'info': {
+                    'title': 'test - v1',
+                    'version': 'v1'
+                },
+                'servers': [
+                    {
+                        'url': '/api'
+                    }
+                ],
+                'paths': {
+                    '/v1/status': {
+                        'get': {
+                            'tags': [
+                                'Status'
+                            ],
+                            'summary': 'Get Status V1',
+                            'operationId': 'get_status_v1_v1_status_get',
+                            'responses': {
+                                '200': {
+                                    'description': 'Successful Response',
+                                    'content': {
+                                        'application/json': {
+                                            'schema': {
+                                                'type': 'string',
+                                                'title': 'Response Get Status V1 V1 Status Get'
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            test_client.get('/v1/api_schema.json').json()
+        )
+        self.assertDictEqual(
+            {
+                'openapi': '3.1.0',
+                'info': {
+                    'title': 'test - v2',
+                    'version': 'v2'
+                },
+                'servers': [
+                    {
+                        'url': '/api'
+                    }
+                ],
+                'paths': {
+                    '/v2/status': {
+                        'get': {
+                            'tags': [
+                                'Status'
+                            ],
+                            'summary': 'Get Status V2',
+                            'operationId': 'get_status_v2_v2_status_get',
+                            'responses': {
+                                '200': {
+                                    'description': 'Successful Response',
+                                    'content': {
+                                        'application/json': {
+                                            'schema': {
+                                                'type': 'string',
+                                                'title': 'Response Get Status V2 V2 Status Get'
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            test_client.get('/v2/api_schema.json').json()
+        )
+        self.assertDictEqual(
+            {
+                'openapi': '3.1.0',
+                'info': {
+                    'title': 'test - v2',
+                    'version': 'v2'
+                },
+                'servers': [
+                    {
+                        'url': '/api'
+                    }
+                ],
+                'paths': {
+                    '/latest/status': {
+                        'get': {
+                            'tags': [
+                                'Status'
+                            ],
+                            'summary': 'Get Status V2',
+                            'operationId': 'get_status_v2_latest_status_get',
+                            'responses': {
+                                '200': {
+                                    'description': 'Successful Response',
+                                    'content': {
+                                        'application/json': {
+                                            'schema': {
+                                                'type': 'string',
+                                                'title': 'Response Get Status V2 Latest Status Get'
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            test_client.get('/latest/api_schema.json').json()
+        )


### PR DESCRIPTION
## Pull Request Checklist

- [x] Make sure to read the contributor guide [here](https://github.com/alexschimpf/fastapi-versionizer/tree/main/CONTRIBUTE.md).
- [x] Make sure you are making a pull request against the main branch.
- [x] Make sure your pull request title matches the requested format.
- [x] Make sure to lint, type-check, and run unit and API tests.

## Description
Hi, it's me again. 😄 
I run some apis behind a reverse proxy in combination with a frontend. Therefore, the frontend is played out directly under / and the api accordingly under /api.
In the reverse proxy I then make a stripPrefix so that it is passed on to fastapi without the prefix.
In fastapi I have defined /api as root_path. All API routes remain identical, only the open-api route is changed so that the prefix is correct again in the frontend.
With fastapi-versionizer, however, this only works for the main docs. All versioned docs no longer work.
| Main doc | Versioned Doc|
|---|---|
| ![grafik](https://github.com/alexschimpf/fastapi-versionizer/assets/13227454/c4cf0d38-a9eb-408b-bf5d-4efa87fe70ae) | ![grafik](https://github.com/alexschimpf/fastapi-versionizer/assets/13227454/23b75a2e-54cd-41a7-976a-f114040dd09e) |

## How To Test
That's described here: https://fastapi.tiangolo.com/advanced/behind-a-proxy/#testing-locally-with-traefik
Just replace the prefix (two times) from the routes.toml from "/api/v1" to "/api". Then you can run:
`uvicorn examples.with_root_path:app --reload`

## Note
[Here](https://fastapi.tiangolo.com/advanced/behind-a-proxy/#providing-the-root_path) is described, that you can set a path prefix with uvicorn directly. My problem is, that the app.root_path attribute from fastapi stays empty in this case. I've had a look at the fastapi sourcecode, but I can't find where the uvicorn value comes from. So currently it only works if you set `FastAPI(root_path='/api')` directly.
