### PR TITLE
fix: Tests are not breaking anymore

### DIFF
--- a/tests/test_with_root_path.py
+++ b/tests/test_with_root_path.py
@@ -147,7 +147,7 @@ class TestWitRootPathExample(TestCase):
                     }
                 }
             },
-            test_client.get('/api_schema.json').json()
+            test_client.get('/api/api_schema.json').json()
         )
         self.assertDictEqual(
             {


### PR DESCRIPTION
I the problem is when you define a root_path on FastAPI it's append the root_path to the openapi_url, but not to the docs page. This might be something from FastAPI structure, I tried to find the reason or when this changed but I couldn't find.

## Pull Request Checklist

- [x] Make sure to read the contributor guide [here](https://github.com/alexschimpf/fastapi-versionizer/tree/main/CONTRIBUTE.md).
- [x] Make sure you are making a pull request against the main branch.
- [x] Make sure your pull request title matches the requested format.
- [x] Make sure to lint, type-check, and run unit and API tests.

## Description
The problem is when you define a `root_path` on `FastAPI`, it appends the `root_path` to the `openapi_url`, but not to the docs page.
This might be something from the FastAPI structure. I tried to find out why or when this changed, but I couldn't find it.