### PR TITLE
fix: Fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Set up pnpm
-      - uses: pnpm/action-setup@v4.1.0
+        uses: pnpm/action-setup@v4.1.0
         with:
           version: 10.11.0
       - name: Install dependencies


### PR DESCRIPTION
Typo in the `release.yml` workflow.
Currently, Actions is getting the error "every step must define a `uses` or `run` key".